### PR TITLE
Add --citeproc to org-pandoc-valid-options

### DIFF
--- a/ox-pandoc.el
+++ b/ox-pandoc.el
@@ -48,7 +48,7 @@
 
 (defconst org-pandoc-valid-options
   '(abbreviations ascii atx-headers base-header-level bash-completion
-    biblatex bibliography citation-abbreviations columns csl css
+    biblatex bibliography citation-abbreviations citeproc columns csl css
     data-dir default-image-extension dpi dump-args email-obfuscation eol
     epub-chapter-level epub-cover-image epub-embed-font epub-metadata
     epub-subdirectory extract-media fail-if-warnings file-scope filter


### PR DESCRIPTION
As per #73, adds citeproc to the list of valid pandoc options so that ox-pandoc works with the latest versions of pandoc in which the pandoc-citeproc filter is deprecated in favour of the built-in citeproc.